### PR TITLE
Read secrets at runtime instead of inlining them into the build

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { defineConfig } from 'astro/config';
+import { defineConfig, envField } from 'astro/config';
 import netlify from '@astrojs/netlify';
 
 // Static by default — every marketing/portfolio page is prerendered at build
@@ -10,6 +10,24 @@ export default defineConfig({
   output: 'static',
   adapter: netlify(),
   build: { inlineStylesheets: 'auto' },
+
+  // Declared as server-side secrets so Astro reads them from the runtime
+  // environment instead of letting Vite inline the literal values into the
+  // built server bundle. That keeps the deploy artifacts free of credentials,
+  // lets Netlify's "contains secret values" scanning pass, and means rotating
+  // a secret takes effect without a rebuild.
+  //
+  // `optional: true` on every field is deliberate: a missing variable must
+  // leave the feature it guards locked, not crash the whole site at boot.
+  env: {
+    schema: {
+      DATABASE_URL: envField.string({ context: 'server', access: 'secret', optional: true }),
+      BLOG_API_TOKEN: envField.string({ context: 'server', access: 'secret', optional: true }),
+      ADMIN_PASSWORD: envField.string({ context: 'server', access: 'secret', optional: true }),
+      CASE_STUDY_PASSWORD: envField.string({ context: 'server', access: 'secret', optional: true }),
+      SESSION_SECRET: envField.string({ context: 'server', access: 'secret', optional: true }),
+    },
+  },
   vite: {
     build: { cssMinify: 'lightningcss' },
   },

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -14,8 +14,11 @@
  * panel, never an open one.
  */
 
+import { getSecret } from 'astro:env/server';
+
 const COOKIE = 'admin_session';
 const MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+
 
 const enc = new TextEncoder();
 
@@ -27,10 +30,10 @@ const clean = (v: string | undefined): string | null =>
   typeof v === 'string' && v.length > 0 ? v : null;
 
 const secret = (): string | null =>
-  clean(import.meta.env.SESSION_SECRET ?? process.env.SESSION_SECRET);
+  clean(getSecret('SESSION_SECRET'));
 
 const expectedPassword = (): string | null =>
-  clean(import.meta.env.ADMIN_PASSWORD ?? process.env.ADMIN_PASSWORD);
+  clean(getSecret('ADMIN_PASSWORD'));
 
 async function hmac(value: string, key: string): Promise<string> {
   const cryptoKey = await crypto.subtle.importKey(

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,5 @@
 import { neon, type NeonQueryFunction } from '@neondatabase/serverless';
+import { getSecret } from 'astro:env/server';
 
 /**
  * Neon's HTTP driver — one round trip per query, no pooling to manage, which
@@ -13,7 +14,7 @@ let client: NeonQueryFunction<false, false> | null = null;
 
 export function sql(): NeonQueryFunction<false, false> {
   if (!client) {
-    const url = import.meta.env.DATABASE_URL ?? process.env.DATABASE_URL;
+    const url = getSecret('DATABASE_URL');
     if (!url) {
       throw new Error('DATABASE_URL is not set — the blog cannot reach Postgres.');
     }
@@ -22,5 +23,4 @@ export function sql(): NeonQueryFunction<false, false> {
   return client;
 }
 
-export const hasDatabase = (): boolean =>
-  Boolean(import.meta.env.DATABASE_URL ?? process.env.DATABASE_URL);
+export const hasDatabase = (): boolean => Boolean(getSecret('DATABASE_URL'));

--- a/src/lib/unlock.ts
+++ b/src/lib/unlock.ts
@@ -8,19 +8,21 @@
  * of unlocking is an HMAC-signed cookie that the client cannot forge.
  */
 
+import { getSecret } from 'astro:env/server';
+
 const COOKIE = 'case_unlock';
 const MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 
 const enc = new TextEncoder();
 
 const secret = (): string => {
-  const s = import.meta.env.SESSION_SECRET ?? process.env.SESSION_SECRET;
+  const s = getSecret('SESSION_SECRET');
   if (!s) throw new Error('SESSION_SECRET is not set — cannot verify case-study unlocking.');
   return s;
 };
 
 const expectedPassword = (): string | null =>
-  import.meta.env.CASE_STUDY_PASSWORD ?? process.env.CASE_STUDY_PASSWORD ?? null;
+  getSecret('CASE_STUDY_PASSWORD') ?? null;
 
 async function hmac(value: string): Promise<string> {
   const key = await crypto.subtle.importKey(

--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro';
 import { sql, hasDatabase } from '../../lib/db';
 import { handleRpc, type JsonRpcRequest, type ToolDefinition, PROTOCOL_VERSION } from '../../lib/mcp';
 import { autoExcerpt } from '../../lib/markdown';
+import { getSecret } from 'astro:env/server';
 
 export const prerender = false;
 
@@ -18,7 +19,7 @@ const slugify = (s: string): string =>
 
 const estimateMinutes = (md: string): number => Math.max(1, Math.round(md.split(/\s+/).length / 220));
 
-const token = (): string | null => import.meta.env.BLOG_API_TOKEN ?? process.env.BLOG_API_TOKEN ?? null;
+const token = (): string | null => getSecret('BLOG_API_TOKEN') ?? null;
 
 /**
  * The request is authorised if it presents the shared secret either as a bearer


### PR DESCRIPTION
Prerequisite for enabling Netlify's **"Contains secret values"** flag on the environment variables.

## The problem

Vite statically replaces `import.meta.env.X` at build time, so every secret was being compiled as a literal into the built server bundle. Verified by grepping the build output for the actual values:

```
DATABASE_URL           FOUND in .netlify/.../chunks/db_*.mjs
BLOG_API_TOKEN         FOUND in .netlify/.../chunks/mcp_*.mjs
CASE_STUDY_PASSWORD    FOUND in .netlify/.../chunks/unlock_*.mjs
SESSION_SECRET         FOUND in .netlify/.../chunks/unlock_*.mjs, admin_*.mjs
ADMIN_PASSWORD         FOUND in .netlify/.../chunks/admin_*.mjs
```

The `?? process.env.X` fallbacks never executed — the left-hand side had already been substituted with the literal.

Nothing was publicly exposed (these are server chunks, not client bundles), but it meant credentials sat in deploy artifacts and build caches, rotating a secret required a full rebuild, and turning on secrets scanning would have **failed the build**.

## The fix

Declares the five variables as server-side secrets via `astro:env` in `astro.config.mjs` and reads them with `getSecret()`, which compiles to a runtime lookup instead of a literal.

All five are `optional: true` on purpose: a missing variable must leave the feature it guards locked, not crash the site at boot.

## Verification

Re-scanned the build output after the change — **no secret appears anywhere** in `dist/` or `.netlify/`.

Runtime re-tested locally, all still working:
- database reads (`/blog/gatsby-as-a-design-tool` → 200)
- case-study unlock (303 + cookie, protected content appears)
- admin login (303 + session cookie)
- MCP bearer auth (valid token → 6 tools; invalid → 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)