### PR TITLE
Add post authoring, editing and image upload to the admin console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/netlify": "^8.1.2",
         "@neondatabase/serverless": "^1.1.0",
+        "@netlify/blobs": "^10.7.10",
         "astro": "^7.1.3",
         "marked": "^18.0.7"
       },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@astrojs/netlify": "^8.1.2",
     "@neondatabase/serverless": "^1.1.0",
+    "@netlify/blobs": "^10.7.10",
     "astro": "^7.1.3",
     "marked": "^18.0.7"
   },

--- a/src/components/PostForm.astro
+++ b/src/components/PostForm.astro
@@ -1,0 +1,688 @@
+---
+/**
+ * The post editor, shared by /admin/new and /admin/edit/[slug].
+ *
+ * Deliberately dumb: it renders the values it is handed and posts back to the
+ * page it sits on. All validation, slugging and writing happens in the page's
+ * frontmatter, which means a rejected submission can re-render this component
+ * with everything the author typed still in place — no redirect, no lost draft.
+ */
+import { kindLabel, type PostKind, type PostStatus } from '../lib/posts';
+import { ACCEPT_ATTRIBUTE } from '../lib/media';
+
+export interface PostFormValues {
+  title: string;
+  slug: string;
+  kind: PostKind;
+  excerpt: string;
+  body: string;
+  tags: string;
+  coverImage: string;
+  featured: boolean;
+}
+
+interface Props {
+  mode: 'new' | 'edit';
+  values: PostFormValues;
+  /** Field name → message. Presence of a key marks that field invalid. */
+  errors?: Record<string, string>;
+  /** Current slug, for the edit form's "this changes the URL" warning. */
+  slug?: string;
+  /** Current stored status, so edit can offer "Save & publish" on a draft. */
+  currentStatus?: PostStatus;
+}
+
+const { mode, values, errors = {}, slug, currentStatus } = Astro.props;
+
+const isEdit = mode === 'edit';
+const kinds: PostKind[] = ['essay', 'book-note'];
+---
+
+<form class="form" method="post">
+  <div class:list={['field', errors.title && 'field--bad']}>
+    <label class="field__label" for="post-title">Title</label>
+    <input
+      class="field__input"
+      id="post-title"
+      name="title"
+      type="text"
+      value={values.title}
+      autocomplete="off"
+      spellcheck="true"
+      required
+      aria-describedby={errors.title ? 'err-title' : undefined}
+    />
+    {
+      errors.title && (
+        <p class="field__error" id="err-title" role="alert">
+          {errors.title}
+        </p>
+      )
+    }
+  </div>
+
+  <div class:list={['field', errors.slug && 'field--bad']}>
+    <label class="field__label" for="post-slug">Slug</label>
+    <input
+      class="field__input field__input--mono"
+      id="post-slug"
+      name="slug"
+      type="text"
+      value={values.slug}
+      placeholder={isEdit ? '' : 'Derived from the title if left blank'}
+      autocomplete="off"
+      spellcheck="false"
+      aria-describedby={errors.slug ? 'err-slug' : 'hint-slug'}
+    />
+    <p class="field__hint" id="hint-slug">
+      {
+        isEdit ? (
+          <>
+            This is the post's URL — <code>/blog/{slug}</code>. Changing it changes the address and
+            the old one stops working.
+          </>
+        ) : (
+          <>Lower case, hyphenated. Leave it blank to derive one from the title.</>
+        )
+      }
+    </p>
+    {
+      errors.slug && (
+        <p class="field__error" id="err-slug" role="alert">
+          {errors.slug}
+        </p>
+      )
+    }
+  </div>
+
+  <div class="field">
+    <label class="field__label" for="post-kind">Kind</label>
+    <select class="field__input field__select" id="post-kind" name="kind">
+      {
+        kinds.map((k) => (
+          <option value={k} selected={values.kind === k}>
+            {kindLabel(k)}
+          </option>
+        ))
+      }
+    </select>
+  </div>
+
+  <div class="field">
+    <label class="field__label" for="post-excerpt">Excerpt</label>
+    <textarea class="field__input field__textarea" id="post-excerpt" name="excerpt" rows="3"
+      spellcheck="true" aria-describedby="hint-excerpt">{values.excerpt}</textarea>
+    <p class="field__hint" id="hint-excerpt">
+      The standfirst shown in listings. Left blank, it is taken from the first paragraph of the body.
+    </p>
+  </div>
+
+  <div class:list={['field', 'field--body', errors.body && 'field--bad']}>
+    <div class="field__head">
+      <label class="field__label" for="post-body">Body</label>
+
+      {/* Hidden until the script un-hides it: with JS off a file input here
+          would be a dead control, and the body is still typed by hand. */}
+      <div class="uploader uploader--inline" id="body-uploader" hidden>
+        <label class="uploader__pick" for="body-file">Insert image</label>
+        <input
+          class="uploader__file"
+          id="body-file"
+          type="file"
+          accept={ACCEPT_ATTRIBUTE}
+          data-target="post-body"
+        />
+        <p class="uploader__status" id="body-status" role="status" aria-live="polite"></p>
+      </div>
+    </div>
+
+    <textarea
+      class="field__input field__body"
+      id="post-body"
+      name="body"
+      rows="26"
+      spellcheck="true"
+      required
+      aria-describedby={errors.body ? 'err-body' : 'hint-body'}>{values.body}</textarea>
+    <p class="field__hint" id="hint-body">Markdown. Inline HTML is allowed.</p>
+    {
+      errors.body && (
+        <p class="field__error" id="err-body" role="alert">
+          {errors.body}
+        </p>
+      )
+    }
+  </div>
+
+  <div class="field">
+    <label class="field__label" for="post-tags">Tags</label>
+    <input
+      class="field__input"
+      id="post-tags"
+      name="tags"
+      type="text"
+      value={values.tags}
+      placeholder="design, tooling"
+      autocomplete="off"
+      spellcheck="false"
+      aria-describedby="hint-tags"
+    />
+    <p class="field__hint" id="hint-tags">Comma separated. Optional.</p>
+  </div>
+
+  <div class="field">
+    <label class="field__label" for="post-cover">Cover image</label>
+
+    {/* The text input is the real field and always works on its own — paste a
+        path to an existing asset and save. Uploading just fills it in. */}
+    <input
+      class="field__input field__input--mono"
+      id="post-cover"
+      name="cover_image"
+      type="text"
+      value={values.coverImage}
+      placeholder="/img/foo.webp"
+      autocomplete="off"
+      spellcheck="false"
+      aria-describedby="hint-cover"
+    />
+
+    <div class="cover" id="cover-block" hidden>
+      <img
+        class="cover__thumb"
+        id="cover-thumb"
+        src={values.coverImage || undefined}
+        alt=""
+        hidden={!values.coverImage}
+      />
+
+      <div class="uploader" id="cover-uploader">
+        <div class="uploader__row">
+          <label class="uploader__pick" for="cover-file">Upload image</label>
+          <input class="uploader__file" id="cover-file" type="file" accept={ACCEPT_ATTRIBUTE} />
+          <button class="uploader__clear" id="cover-clear" type="button">Clear</button>
+        </div>
+        <p class="uploader__status" id="cover-status" role="status" aria-live="polite"></p>
+      </div>
+    </div>
+
+    <p class="field__hint" id="hint-cover">
+      A path to an existing asset, or upload one. Images are stored as-is — no resizing.
+    </p>
+  </div>
+
+  <div class="field field--check">
+    <label class="check">
+      <input class="check__box" type="checkbox" name="featured" checked={values.featured} />
+      <span class="check__text">Featured — pinned to the top of the blog</span>
+    </label>
+  </div>
+
+  {/* The first submit button is the one Enter triggers from a text field, so the
+      safe action goes first and gets the primary weight. Publishing is always a
+      deliberate second click. */}
+  <div class="form__actions">
+    {
+      isEdit ? (
+        <>
+          <button class="btn btn--dark" type="submit" name="action" value="save">
+            Save
+          </button>
+          {currentStatus === 'draft' && (
+            <button class="btn btn--ghost-light" type="submit" name="action" value="publish">
+              Save &amp; publish
+            </button>
+          )}
+        </>
+      ) : (
+        <>
+          <button class="btn btn--dark" type="submit" name="action" value="draft">
+            Save as draft
+          </button>
+          <button class="btn btn--ghost-light" type="submit" name="action" value="publish">
+            Publish
+          </button>
+        </>
+      )
+    }
+    <a class="form__cancel" href="/admin">Cancel</a>
+  </div>
+</form>
+
+<script>
+  /**
+   * Image upload, layered on top of a form that already works without it.
+   *
+   * Nothing here is required to save a post: the upload controls start hidden
+   * and are only revealed once this script runs, the cover field stays an
+   * ordinary text input, and a failed upload leaves the form exactly as it was.
+   */
+  const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T | null;
+
+  const coverBlock = $<HTMLDivElement>('cover-block');
+  const coverInput = $<HTMLInputElement>('post-cover');
+  const coverFile = $<HTMLInputElement>('cover-file');
+  const coverThumb = $<HTMLImageElement>('cover-thumb');
+  const coverClear = $<HTMLButtonElement>('cover-clear');
+  const coverStatus = $<HTMLParagraphElement>('cover-status');
+
+  const bodyBlock = $<HTMLDivElement>('body-uploader');
+  const bodyFile = $<HTMLInputElement>('body-file');
+  const bodyArea = $<HTMLTextAreaElement>('post-body');
+  const bodyStatus = $<HTMLParagraphElement>('body-status');
+
+  const say = (el: HTMLElement | null, message: string, state: 'busy' | 'error' | 'ok' | '' = '') => {
+    if (!el) return;
+    el.textContent = message;
+    if (state) el.dataset.state = state;
+    else delete el.dataset.state;
+  };
+
+  interface Uploaded {
+    url: string;
+    name: string;
+    width?: number;
+    height?: number;
+  }
+
+  /** XHR rather than fetch, purely for the upload progress events. */
+  const upload = (file: File, onProgress: (percent: number) => void): Promise<Uploaded> =>
+    new Promise((resolve, reject) => {
+      const body = new FormData();
+      body.append('file', file);
+
+      const xhr = new XMLHttpRequest();
+      xhr.open('POST', '/api/admin/upload');
+      xhr.responseType = 'json';
+
+      xhr.upload.addEventListener('progress', (event) => {
+        if (event.lengthComputable) onProgress(Math.round((event.loaded / event.total) * 100));
+      });
+
+      xhr.addEventListener('load', () => {
+        const data = xhr.response as (Uploaded & { error?: string }) | null;
+        if (xhr.status >= 200 && xhr.status < 300 && data?.url) resolve(data);
+        else if (xhr.status === 403) reject(new Error('Your session has expired — log in again.'));
+        else reject(new Error(data?.error || `Upload failed (${xhr.status}).`));
+      });
+
+      xhr.addEventListener('error', () => reject(new Error('Upload failed — check your connection.')));
+      xhr.send(body);
+    });
+
+  const showCover = (value: string) => {
+    if (!coverThumb) return;
+    if (value) {
+      coverThumb.src = value;
+      coverThumb.hidden = false;
+    } else {
+      coverThumb.removeAttribute('src');
+      coverThumb.hidden = true;
+    }
+  };
+
+  /* ------------------------------------------------------------------ cover */
+  if (coverBlock && coverInput && coverFile) {
+    coverBlock.hidden = false;
+
+    coverInput.addEventListener('change', () => showCover(coverInput.value.trim()));
+    coverThumb?.addEventListener('error', () => {
+      coverThumb.hidden = true;
+    });
+
+    coverClear?.addEventListener('click', () => {
+      coverInput.value = '';
+      coverFile.value = '';
+      showCover('');
+      say(coverStatus, '');
+    });
+
+    coverFile.addEventListener('change', async () => {
+      const file = coverFile.files?.[0];
+      if (!file) return;
+
+      say(coverStatus, `Uploading ${file.name}…`, 'busy');
+      try {
+        const result = await upload(file, (p) => say(coverStatus, `Uploading ${file.name} — ${p}%`, 'busy'));
+        coverInput.value = result.url;
+        showCover(result.url);
+        const size = result.width && result.height ? ` · ${result.width}×${result.height}` : '';
+        say(coverStatus, `${result.name} uploaded${size}`, 'ok');
+      } catch (error) {
+        say(coverStatus, (error as Error).message, 'error');
+      } finally {
+        coverFile.value = '';
+      }
+    });
+  }
+
+  /* ------------------------------------------------------------------- body */
+  if (bodyBlock && bodyFile && bodyArea) {
+    bodyBlock.hidden = false;
+
+    bodyFile.addEventListener('change', async () => {
+      const file = bodyFile.files?.[0];
+      if (!file) return;
+
+      // Remember where the caret was before the file dialog stole focus.
+      const start = bodyArea.selectionStart;
+      const end = bodyArea.selectionEnd;
+
+      say(bodyStatus, `Uploading ${file.name}…`, 'busy');
+      try {
+        const result = await upload(file, (p) => say(bodyStatus, `Uploading ${file.name} — ${p}%`, 'busy'));
+
+        const alt = (result.name || 'image').replace(/\.[^.]*$/, '').replace(/[-_]+/g, ' ').trim();
+        const text = bodyArea.value;
+        // Sit the image on its own block, but only add the blank lines that
+        // are actually missing, so inserting mid-paragraph does not rewrap it.
+        const before = text.slice(0, start);
+        const after = text.slice(end);
+        const lead = before === '' || before.endsWith('\n\n') ? '' : before.endsWith('\n') ? '\n' : '\n\n';
+        const trail = after === '' || after.startsWith('\n\n') ? '' : after.startsWith('\n') ? '\n' : '\n\n';
+        const snippet = `${lead}![${alt}](${result.url})${trail}`;
+
+        bodyArea.value = before + snippet + after;
+
+        const caret = before.length + snippet.length;
+        bodyArea.focus();
+        bodyArea.setSelectionRange(caret, caret);
+
+        const size = result.width && result.height ? ` · ${result.width}×${result.height}` : '';
+        say(bodyStatus, `Inserted ${result.name}${size}`, 'ok');
+      } catch (error) {
+        say(bodyStatus, (error as Error).message, 'error');
+        bodyArea.focus();
+      } finally {
+        bodyFile.value = '';
+      }
+    });
+  }
+</script>
+
+<style>
+  /* Same vocabulary as the console: hairline rules, uppercase micro-labels,
+     one column all the way down so a long body gets the full measure. */
+  .form {
+    max-width: 780px;
+    border-top: 1px solid var(--rule-light);
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-block: 24px;
+    border-bottom: 1px solid var(--rule-light);
+  }
+
+  .field__label {
+    font-size: 11px;
+    font-weight: var(--w-bold);
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-on-light-soft);
+  }
+
+  .field--bad .field__label {
+    color: var(--rust);
+  }
+
+  .field__input {
+    width: 100%;
+    min-height: 52px;
+    padding: 14px 16px;
+    border: 1px solid var(--border-input);
+    background: var(--paper);
+    font-family: inherit;
+    font-size: 16px;
+    font-weight: var(--w-light);
+    line-height: 1.5;
+    color: var(--text-on-light);
+    outline: none;
+  }
+
+  .field__input:focus-visible {
+    outline: 2px solid var(--gold);
+    outline-offset: -2px;
+  }
+
+  .field--bad .field__input {
+    border-color: var(--rust);
+  }
+
+  .field__input--mono {
+    font-family: var(--font-mono);
+    font-size: 14px;
+  }
+
+  .field__select {
+    appearance: none;
+    padding-inline: 16px;
+    background-image: linear-gradient(45deg, transparent 50%, var(--text-on-light-soft) 50%),
+      linear-gradient(135deg, var(--text-on-light-soft) 50%, transparent 50%);
+    background-position:
+      calc(100% - 20px) calc(50% + 1px),
+      calc(100% - 14px) calc(50% + 1px);
+    background-size:
+      6px 6px,
+      6px 6px;
+    background-repeat: no-repeat;
+    padding-right: 44px;
+  }
+
+  .field__textarea {
+    resize: vertical;
+    min-height: 92px;
+  }
+
+  /* The body is the point of this screen — mono, roomy, and it grows. */
+  .field__body {
+    resize: vertical;
+    min-height: 520px;
+    padding: 18px;
+    font-family: var(--font-mono);
+    font-size: 14px;
+    line-height: 1.75;
+    tab-size: 2;
+  }
+
+  .field__hint {
+    font-size: 13px;
+    font-weight: var(--w-light);
+    line-height: 1.5;
+    color: var(--text-on-light-soft);
+  }
+
+  .field__hint code {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-on-light-muted);
+    overflow-wrap: anywhere;
+  }
+
+  .field__error {
+    font-size: 13px;
+    font-weight: var(--w-medium);
+    line-height: 1.5;
+    padding-left: 12px;
+    border-left: 3px solid var(--rust);
+    color: var(--rust);
+  }
+
+  /* ------------------------------------------------------------- uploader */
+  .field__head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px 16px;
+  }
+
+  .uploader__row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+  }
+
+  /* The real input is hidden and driven by its label, so the control matches
+     the .act buttons in the console instead of the browser's file widget. */
+  .uploader__file {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .uploader__pick,
+  .uploader__clear {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 38px;
+    padding-inline: 14px;
+    border: 1px solid var(--border-input);
+    background: transparent;
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: var(--w-bold);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-on-light);
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .uploader__pick:hover,
+  .uploader__clear:hover {
+    border-color: var(--rust);
+    color: var(--rust);
+  }
+
+  .uploader:has(.uploader__file:focus-visible) .uploader__pick {
+    outline: 2px solid var(--gold);
+    outline-offset: 2px;
+  }
+
+  /* These blocks are laid out with flex, which would otherwise beat the
+     `hidden` attribute they start life with. */
+  [hidden] {
+    display: none !important;
+  }
+
+  .uploader--inline {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px 14px;
+  }
+
+  .uploader__status {
+    font-size: 12px;
+    font-weight: var(--w-light);
+    line-height: 1.5;
+    color: var(--text-on-light-soft);
+  }
+
+  .uploader__status[data-state='error'] {
+    font-weight: var(--w-medium);
+    color: var(--rust);
+  }
+
+  .cover {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    margin-top: 2px;
+  }
+
+  .cover__thumb {
+    width: 96px;
+    height: 72px;
+    flex: none;
+    object-fit: cover;
+    border: 1px solid var(--rule-light);
+    background: var(--paper-warm);
+  }
+
+  /* ------------------------------------------------------------- checkbox */
+  .field--check {
+    padding-block: 22px;
+  }
+
+  .check {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+  }
+
+  .check__box {
+    width: 18px;
+    height: 18px;
+    flex: none;
+    accent-color: var(--rust);
+    cursor: pointer;
+  }
+
+  .check__text {
+    font-size: 15px;
+    font-weight: var(--w-light);
+    color: var(--text-on-light-muted);
+  }
+
+  /* -------------------------------------------------------------- actions */
+  .form__actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 14px;
+    padding-top: 28px;
+  }
+
+  .form__actions .btn {
+    min-height: 50px;
+    cursor: pointer;
+  }
+
+  .form__cancel {
+    margin-left: 6px;
+    font-size: 13px;
+    font-weight: var(--w-medium);
+    letter-spacing: 0.06em;
+    color: var(--text-on-light-soft);
+  }
+
+  .form__cancel:hover {
+    color: var(--rust);
+  }
+
+  /* ----------------------------------------------------------- responsive */
+  @media (max-width: 720px) {
+    .field__body {
+      min-height: 420px;
+      font-size: 13px;
+    }
+
+    .form__actions .btn {
+      flex: 1 1 auto;
+    }
+
+    /* Same 44px touch target the console's row actions use on small screens. */
+    .uploader__pick,
+    .uploader__clear {
+      min-height: 44px;
+    }
+
+    .form__cancel {
+      margin-left: 0;
+      width: 100%;
+      padding-top: 6px;
+    }
+  }
+</style>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -70,15 +70,14 @@ const pathname = Astro.url.pathname;
     --nav-rule: var(--rule-light);
   }
 
+  /* One value for both treatments. The prototype set the dark header to 26px
+     and the light one to 20px, which read as an inconsistency when moving
+     between pages rather than as an intentional difference. */
   .site-header__inner {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 24px;
-    padding-block: 20px;
-  }
-
-  .site-header--dark .site-header__inner {
     padding-block: 26px;
   }
 

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -1,0 +1,251 @@
+/**
+ * Storage and identification for post images.
+ *
+ * Images uploaded from the admin editor go into a Netlify Blobs store and are
+ * served back from /media/<key>. Two rules shape everything here:
+ *
+ *  1. The file type is decided by the bytes, never by the browser. A
+ *     Content-Type header and a filename extension are both attacker-supplied,
+ *     so an "image/png" claim on an HTML file would otherwise be enough to get
+ *     stored content served from our own origin.
+ *  2. The key is a content hash plus a slugified name. Re-uploading the same
+ *     file lands on the same key (idempotent, no duplicates), two different
+ *     files can never collide, and nothing about the key can be guessed from
+ *     the filename alone.
+ */
+
+import { slugify } from './posts';
+
+export const MEDIA_PATH = '/media/';
+export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
+const STORE_NAME = 'post-media';
+
+/** The only types we accept. No SVG: it is a script container, not a picture. */
+export const MIME_BY_EXT: Record<string, string> = {
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+  gif: 'image/gif',
+  avif: 'image/avif',
+};
+
+export const ACCEPT_ATTRIBUTE = 'image/jpeg,image/png,image/webp,image/gif,image/avif';
+
+export interface ImageType {
+  mime: string;
+  ext: string;
+}
+
+/* --------------------------------------------------------------- sniffing */
+
+const ascii = (b: Uint8Array, at: number, len: number): string =>
+  String.fromCharCode(...b.subarray(at, at + len));
+
+/**
+ * Identify an image from its magic bytes, or return null.
+ *
+ * Anything not recognised here is rejected — an allow-list of five container
+ * formats, not a deny-list of known-bad ones.
+ */
+export function sniffImage(bytes: Uint8Array): ImageType | null {
+  if (bytes.length < 16) return null;
+
+  // PNG — the full 8-byte signature.
+  if (
+    bytes[0] === 0x89 &&
+    ascii(bytes, 1, 3) === 'PNG' &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return { mime: 'image/png', ext: 'png' };
+  }
+
+  // JPEG — SOI followed by any marker.
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return { mime: 'image/jpeg', ext: 'jpg' };
+  }
+
+  // GIF87a / GIF89a.
+  const gif = ascii(bytes, 0, 6);
+  if (gif === 'GIF87a' || gif === 'GIF89a') {
+    return { mime: 'image/gif', ext: 'gif' };
+  }
+
+  // WebP — a RIFF container whose form type is WEBP.
+  if (ascii(bytes, 0, 4) === 'RIFF' && ascii(bytes, 8, 4) === 'WEBP') {
+    return { mime: 'image/webp', ext: 'webp' };
+  }
+
+  // AVIF — an ISO-BMFF `ftyp` box declaring an AVIF brand, either as the major
+  // brand or among the compatible brands that follow it.
+  if (ascii(bytes, 4, 4) === 'ftyp') {
+    const boxSize = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(0);
+    const end = Math.min(boxSize > 0 ? boxSize : 0, bytes.length);
+    for (let at = 8; at + 4 <= end; at += 4) {
+      const brand = ascii(bytes, at, 4);
+      if (brand === 'avif' || brand === 'avis') return { mime: 'image/avif', ext: 'avif' };
+    }
+  }
+
+  return null;
+}
+
+/* ------------------------------------------------------------- dimensions */
+
+/**
+ * Intrinsic pixel size, best effort.
+ *
+ * Used only to tell the author what they just uploaded, so an unparsed file
+ * (notably AVIF, whose size lives in a nested `ispe` box) simply returns null
+ * rather than costing us a decoder dependency.
+ */
+export function imageSize(bytes: Uint8Array, ext: string): { width: number; height: number } | null {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+  try {
+    if (ext === 'png' && ascii(bytes, 12, 4) === 'IHDR') {
+      return { width: view.getUint32(16), height: view.getUint32(20) };
+    }
+
+    if (ext === 'gif') {
+      return { width: view.getUint16(6, true), height: view.getUint16(8, true) };
+    }
+
+    if (ext === 'webp') {
+      const chunk = ascii(bytes, 12, 4);
+      if (chunk === 'VP8 ') {
+        return { width: view.getUint16(26, true) & 0x3fff, height: view.getUint16(28, true) & 0x3fff };
+      }
+      if (chunk === 'VP8L') {
+        const bits = view.getUint32(21, true);
+        return { width: (bits & 0x3fff) + 1, height: ((bits >> 14) & 0x3fff) + 1 };
+      }
+      if (chunk === 'VP8X') {
+        const read24 = (at: number) => bytes[at] | (bytes[at + 1] << 8) | (bytes[at + 2] << 16);
+        return { width: read24(24) + 1, height: read24(27) + 1 };
+      }
+      return null;
+    }
+
+    if (ext === 'jpg') {
+      // Walk the marker chain to the first start-of-frame, which carries the size.
+      let at = 2;
+      while (at + 9 < bytes.length) {
+        if (bytes[at] !== 0xff) {
+          at += 1;
+          continue;
+        }
+        const marker = bytes[at + 1];
+        if (marker === 0xff || marker === 0x01 || (marker >= 0xd0 && marker <= 0xd9)) {
+          at += 2;
+          continue;
+        }
+        const length = view.getUint16(at + 2);
+        const isFrame = marker >= 0xc0 && marker <= 0xcf && ![0xc4, 0xc8, 0xcc].includes(marker);
+        if (isFrame) return { height: view.getUint16(at + 5), width: view.getUint16(at + 7) };
+        if (length < 2) return null;
+        at += 2 + length;
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+/* -------------------------------------------------------------------- keys */
+
+const KEY_PATTERN = /^[0-9a-f]{24}-[a-z0-9-]{1,48}\.(jpg|png|webp|gif|avif)$/;
+
+export const isMediaKey = (key: string): boolean => KEY_PATTERN.test(key);
+
+export const extensionOf = (key: string): string => key.slice(key.lastIndexOf('.') + 1);
+
+/** `<24 hex of sha-256>-<slugified original name>.<sniffed extension>` */
+export async function mediaKey(bytes: Uint8Array, filename: string, ext: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', bytes as unknown as ArrayBuffer);
+  const hash = [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 24);
+
+  const base = filename.replace(/\.[^.]*$/, '');
+  const name = slugify(base).slice(0, 48) || 'image';
+
+  return `${hash}-${name}.${ext}`;
+}
+
+/* ------------------------------------------------------------------ store */
+
+export interface StoredMedia {
+  bytes: Uint8Array;
+  mime: string;
+}
+
+export interface MediaStore {
+  put(key: string, bytes: Uint8Array, mime: string): Promise<void>;
+  get(key: string): Promise<StoredMedia | null>;
+}
+
+const netlifyStore = async (): Promise<MediaStore> => {
+  const { getStore } = await import('@netlify/blobs');
+  // Strong consistency: the editor asks for the image it just uploaded almost
+  // immediately, so eventual consistency would show a broken thumbnail.
+  const store = getStore({ name: STORE_NAME, consistency: 'strong' });
+
+  return {
+    async put(key, bytes, mime) {
+      await store.set(key, bytes as unknown as ArrayBuffer, { metadata: { mime } });
+    },
+    async get(key) {
+      const result = await store.getWithMetadata(key, { type: 'arrayBuffer' });
+      if (!result) return null;
+      const mime = typeof result.metadata?.mime === 'string' ? result.metadata.mime : '';
+      return { bytes: new Uint8Array(result.data), mime };
+    },
+  };
+};
+
+/**
+ * Local-development fallback.
+ *
+ * `astro dev` runs outside the Netlify runtime, so there is no Blobs context to
+ * connect to. Rather than make image upload untestable locally, dev writes into
+ * .netlify/media-dev/ instead. This is reached only when Blobs is genuinely
+ * unavailable *and* we are in dev — in production a Blobs failure must surface
+ * as an error, never silently write to a function's ephemeral disk.
+ */
+const devFileStore = async (): Promise<MediaStore> => {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const dir = path.join(process.cwd(), '.netlify', 'media-dev');
+
+  return {
+    async put(key, bytes, mime) {
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, key), bytes);
+      await fs.writeFile(path.join(dir, `${key}.type`), mime, 'utf8');
+    },
+    async get(key) {
+      try {
+        const bytes = await fs.readFile(path.join(dir, key));
+        const mime = await fs.readFile(path.join(dir, `${key}.type`), 'utf8').catch(() => '');
+        return { bytes: new Uint8Array(bytes), mime };
+      } catch {
+        return null;
+      }
+    },
+  };
+};
+
+export async function mediaStore(): Promise<MediaStore> {
+  try {
+    return await netlifyStore();
+  } catch (error) {
+    if (import.meta.env.DEV) return devFileStore();
+    throw error;
+  }
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -68,6 +68,27 @@ export async function getPost(slug: string): Promise<Post | null> {
   return rows.length ? toPost(rows[0]) : null;
 }
 
+/**
+ * URL slug from arbitrary text.
+ *
+ * Shared by the MCP endpoint and the browser admin so a post written in either
+ * place lands on exactly the same slug: lower-cased, decomposed so accents drop
+ * their marks, every other run of non-alphanumerics collapsed to a hyphen, and
+ * capped at 80 characters.
+ */
+export const slugify = (s: string): string =>
+  s
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 80);
+
+/** The `read_minutes` value stamped on write — same 220 wpm as `readingTime`. */
+export const estimateMinutes = (md: string): number =>
+  Math.max(1, Math.round(md.split(/\s+/).length / 220));
+
 /** Human date in the site's style, e.g. "June 28, 2026". */
 export const formatDate = (iso: string | null): string =>
   iso

--- a/src/pages/admin/edit/[slug].astro
+++ b/src/pages/admin/edit/[slug].astro
@@ -1,0 +1,411 @@
+---
+/**
+ * Edit an existing post.
+ *
+ * Like /admin/new, the POST is handled in the page so a validation failure can
+ * re-render the form with the author's text intact instead of redirecting it
+ * into the bin. The UPDATE mirrors the MCP `update_post` handler, including the
+ * rule that `published_at` is stamped only the first time a post goes public.
+ *
+ * One deliberate difference from MCP: this form always submits every field, so
+ * a cleared excerpt or cover image really does clear (or re-derive) the stored
+ * value. MCP's COALESCE semantics exist because it patches a subset of fields;
+ * a form has no way to express "leave this one alone".
+ */
+export const prerender = false;
+
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import PostForm from '../../../components/PostForm.astro';
+import { isAdmin, ADMIN_COOKIE } from '../../../lib/admin';
+import { sql, hasDatabase } from '../../../lib/db';
+import { autoExcerpt } from '../../../lib/markdown';
+import { slugify, estimateMinutes, type PostKind, type PostStatus } from '../../../lib/posts';
+
+let authed = false;
+try {
+  authed = await isAdmin(Astro.cookies.get(ADMIN_COOKIE)?.value);
+} catch {
+  authed = false;
+}
+
+// Never let a CDN or shared cache hand an authenticated page to the next visitor.
+Astro.response.headers.set('Cache-Control', 'private, no-store');
+Astro.response.headers.set('Vary', 'Cookie');
+
+const showError = Astro.url.searchParams.get('error') === '1';
+const slug = Astro.params.slug ?? '';
+
+let values = {
+  title: '',
+  slug: '',
+  kind: 'essay' as PostKind,
+  excerpt: '',
+  body: '',
+  tags: '',
+  coverImage: '',
+  featured: false,
+};
+
+const errors: Record<string, string> = {};
+const dbMissing = authed && !hasDatabase();
+let found = false;
+let currentStatus: PostStatus = 'draft';
+
+/* Nothing is read from the database until the session checks out, so a locked
+   response cannot contain a title, a slug or a line of the body. */
+if (authed && !dbMissing) {
+  const rows = await sql()`SELECT * FROM posts WHERE slug = ${slug} LIMIT 1`;
+
+  if (rows.length) {
+    found = true;
+    const p = rows[0];
+    currentStatus = p.status as PostStatus;
+
+    values = {
+      title: p.title,
+      slug: p.slug,
+      kind: p.kind as PostKind,
+      excerpt: p.excerpt ?? '',
+      body: p.body_md ?? '',
+      tags: (p.tags ?? []).join(', '),
+      coverImage: p.cover_image ?? '',
+      featured: Boolean(p.featured),
+    };
+  }
+}
+
+if (Astro.request.method === 'POST') {
+  if (!authed) return new Response('Forbidden', { status: 403 });
+  if (!hasDatabase()) return new Response('No database configured', { status: 503 });
+  if (!found) return new Response('Not found', { status: 404 });
+
+  let form: FormData;
+  try {
+    form = await Astro.request.formData();
+  } catch {
+    return new Response('Bad request', { status: 400 });
+  }
+
+  const text = (name: string): string => {
+    const v = form.get(name);
+    return typeof v === 'string' ? v : '';
+  };
+
+  values = {
+    title: text('title').trim(),
+    slug: text('slug').trim(),
+    kind: text('kind') === 'book-note' ? 'book-note' : 'essay',
+    excerpt: text('excerpt').trim(),
+    body: text('body'),
+    tags: text('tags'),
+    coverImage: text('cover_image').trim(),
+    featured: form.get('featured') !== null,
+  };
+
+  const publish = text('action') === 'publish';
+
+  if (!values.title) errors.title = 'A title is required.';
+  if (!values.body.trim()) errors.body = 'A body is required.';
+
+  const nextSlug = slugify(values.slug || values.title);
+  if (!nextSlug) errors.slug = 'A slug is required — this post needs a URL.';
+
+  // The post keeping its own slug is not a collision.
+  if (nextSlug && nextSlug !== slug && Object.keys(errors).length === 0) {
+    const clash = await sql()`SELECT slug FROM posts WHERE slug = ${nextSlug} LIMIT 1`;
+    if (clash.length) errors.slug = 'A post with that slug already exists.';
+  }
+
+  if (Object.keys(errors).length === 0) {
+    const tags = values.tags
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    const status: PostStatus = publish ? 'published' : currentStatus;
+
+    // Stamp published_at the first time the post actually goes public, and
+    // leave it alone on every later edit so the original date is preserved.
+    const publishedAt =
+      status === 'published' && currentStatus !== 'published' ? new Date().toISOString() : null;
+
+    await sql()`
+      UPDATE posts SET
+        slug         = ${nextSlug},
+        title        = ${values.title},
+        excerpt      = ${values.excerpt || autoExcerpt(values.body)},
+        body_md      = ${values.body},
+        kind         = ${values.kind},
+        status       = ${status},
+        featured     = ${values.featured},
+        tags         = ${tags},
+        cover_image  = ${values.coverImage || null},
+        read_minutes = ${estimateMinutes(values.body)},
+        published_at = COALESCE(${publishedAt}, published_at)
+      WHERE slug = ${slug}`;
+
+    return Astro.redirect('/admin', 303);
+  }
+
+  Astro.response.status = 422;
+}
+
+if (authed && !dbMissing && !found) Astro.response.status = 404;
+
+const hasErrors = Object.keys(errors).length > 0;
+---
+
+<BaseLayout title="Edit post" description="Blog administration.">
+  <meta slot="head" name="robots" content="noindex, nofollow, noarchive" />
+
+  {
+    !authed ? (
+      <section class="container--reading gate">
+        <p class="eyebrow">Restricted</p>
+        <h1 class="gate__title">Admin</h1>
+        <p class="gate__copy">This area manages the blog. Enter the admin password to continue.</p>
+
+        <form class="gate__form" method="post" action="/api/admin/login">
+          <input type="hidden" name="redirect" value="/admin" />
+          <label class="field__label" for="admin-password">
+            Password
+          </label>
+          <input
+            class="field__input"
+            id="admin-password"
+            name="password"
+            type="password"
+            placeholder="Password"
+            autocomplete="current-password"
+            required
+          />
+          <button class="btn btn--dark" type="submit">
+            Sign in
+          </button>
+        </form>
+
+        {showError && (
+          <p class="msg msg--error" role="alert">
+            That password is not right. Try again.
+          </p>
+        )}
+      </section>
+    ) : (
+      <section class="container admin">
+        <header class="admin__head">
+          <div>
+            <p class="eyebrow">Blog administration</p>
+            <h1 class="admin__title">Edit post</h1>
+            {found && (
+              <p class="admin__count">
+                <span class:list={['pill', `pill--${currentStatus}`]}>{currentStatus}</span>
+                <code class="admin__slug">/blog/{values.slug}</code>
+              </p>
+            )}
+          </div>
+
+          <a class="btn btn--ghost-light" href="/admin">
+            All posts
+          </a>
+        </header>
+
+        {dbMissing && (
+          <p class="msg msg--error" role="alert">
+            DATABASE_URL is not set, so there is nothing to edit here.
+          </p>
+        )}
+
+        {!dbMissing && !found ? (
+          <p class="msg msg--error" role="alert">
+            No post with that slug. It may have been deleted or renamed.
+          </p>
+        ) : (
+          found && (
+            <>
+              {hasErrors && (
+                <p class="msg msg--error" role="alert">
+                  The post was not saved. Fix the fields marked below — nothing you typed was lost.
+                </p>
+              )}
+
+              <PostForm
+                mode="edit"
+                values={values}
+                errors={errors}
+                slug={slug}
+                currentStatus={currentStatus}
+              />
+            </>
+          )
+        )}
+      </section>
+    )
+  }
+</BaseLayout>
+
+<style>
+  /* ------------------------------------------------------------- gate */
+  .gate {
+    padding-block: 90px 120px;
+    max-width: 460px;
+  }
+
+  .gate .eyebrow {
+    margin-bottom: 20px;
+  }
+
+  .gate__title {
+    font-weight: var(--w-black);
+    font-size: 40px;
+    line-height: 1;
+    letter-spacing: -0.02em;
+    margin-bottom: 16px;
+  }
+
+  .gate__copy {
+    font-size: 16px;
+    font-weight: var(--w-light);
+    line-height: 1.6;
+    color: var(--text-on-light-muted);
+    margin-bottom: 32px;
+  }
+
+  .gate__form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .field__label {
+    font-size: 11px;
+    font-weight: var(--w-bold);
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-on-light-soft);
+  }
+
+  .field__input {
+    min-height: 52px;
+    padding-inline: 16px;
+    border: 1px solid var(--border-input);
+    background: var(--paper);
+    font-family: inherit;
+    font-size: 16px;
+    color: var(--text-on-light);
+    outline: none;
+  }
+
+  .field__input:focus-visible {
+    outline: 2px solid var(--gold);
+    outline-offset: -2px;
+  }
+
+  .gate__form .btn {
+    margin-top: 6px;
+  }
+
+  /* ---------------------------------------------------------- messages */
+  .msg {
+    font-size: 14px;
+    line-height: 1.5;
+    padding: 14px 16px;
+    margin-bottom: 24px;
+    border-left: 3px solid var(--gold);
+    background: var(--paper-warm);
+    color: var(--text-on-light-muted);
+  }
+
+  .msg--error {
+    border-left-color: var(--rust);
+    color: var(--rust);
+  }
+
+  .gate .msg {
+    margin-top: 20px;
+    margin-bottom: 0;
+  }
+
+  /* ------------------------------------------------------------ layout */
+  .admin {
+    padding-block: 70px 100px;
+  }
+
+  /* Capped to the form's measure so the head rule and the field hairlines are
+     one continuous column rather than two different widths. */
+  .admin__head,
+  .msg {
+    max-width: 780px;
+  }
+
+  .admin__head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+    padding-bottom: 26px;
+    margin-bottom: 30px;
+    border-bottom: 1px solid var(--rule-light);
+  }
+
+  .admin__head .eyebrow {
+    margin-bottom: 12px;
+  }
+
+  .admin__title {
+    font-weight: var(--w-black);
+    font-size: 40px;
+    line-height: 1;
+    letter-spacing: -0.02em;
+  }
+
+  .admin__count {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px 14px;
+    margin-top: 14px;
+  }
+
+  .admin__slug {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.06em;
+    color: var(--text-on-light-faint);
+    overflow-wrap: anywhere;
+  }
+
+  .pill {
+    font-size: 10px;
+    font-weight: var(--w-bold);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    padding: 4px 8px;
+    border: 1px solid var(--border-input);
+    color: var(--text-on-light-soft);
+  }
+
+  .pill--published {
+    border-color: var(--gold-deep);
+    color: var(--rust);
+  }
+
+  .admin__head .btn {
+    min-height: 44px;
+    flex: none;
+  }
+
+  @media (max-width: 720px) {
+    .admin {
+      padding-block: 50px 80px;
+    }
+
+    .admin__head {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .admin__title {
+      font-size: 32px;
+    }
+  }
+</style>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -120,11 +120,17 @@ const draftCount = posts.length - publishedCount;
             </p>
           </div>
 
-          <form method="post" action="/api/admin/logout">
-            <button class="btn btn--ghost-light" type="submit">
-              Log out
-            </button>
-          </form>
+          <div class="admin__tools">
+            <a class="btn btn--dark" href="/admin/new">
+              New post
+            </a>
+
+            <form method="post" action="/api/admin/logout">
+              <button class="btn btn--ghost-light" type="submit">
+                Log out
+              </button>
+            </form>
+          </div>
         </header>
 
         {justDeleted && (
@@ -171,7 +177,11 @@ const draftCount = posts.length - publishedCount;
             {posts.map((post) => (
               <li class:list={['row', post.slug === confirmSlug && 'row--pending']}>
                 <div class="row__main">
-                  <h2 class="row__title">{post.title}</h2>
+                  <h2 class="row__title">
+                    <a class="row__link" href={`/admin/edit/${post.slug}`}>
+                      {post.title}
+                    </a>
+                  </h2>
                   <p class="row__meta">
                     <span class:list={['pill', `pill--${post.status}`]}>{post.status}</span>
                     <span class="row__kind">{kindLabel(post.kind)}</span>
@@ -183,6 +193,10 @@ const draftCount = posts.length - publishedCount;
                 </div>
 
                 <div class="row__actions">
+                  <a class="act" href={`/admin/edit/${post.slug}`}>
+                    Edit
+                  </a>
+
                   <a class="act act--view" href={`/blog/${post.slug}`}>
                     View
                   </a>
@@ -340,6 +354,13 @@ const draftCount = posts.length - publishedCount;
     flex: none;
   }
 
+  .admin__tools {
+    display: flex;
+    flex: none;
+    align-items: center;
+    gap: 10px;
+  }
+
   .empty {
     padding: 40px 0;
     font-size: 16px;
@@ -430,6 +451,14 @@ const draftCount = posts.length - publishedCount;
     margin-bottom: 8px;
   }
 
+  .row__link {
+    color: inherit;
+  }
+
+  .row__link:hover {
+    color: var(--rust);
+  }
+
   .row__meta {
     display: flex;
     flex-wrap: wrap;
@@ -513,6 +542,14 @@ const draftCount = posts.length - publishedCount;
     .admin__head {
       flex-direction: column;
       align-items: stretch;
+    }
+
+    .admin__tools > * {
+      flex: 1;
+    }
+
+    .admin__tools .btn {
+      width: 100%;
     }
 
     .admin__title {

--- a/src/pages/admin/new.astro
+++ b/src/pages/admin/new.astro
@@ -1,0 +1,331 @@
+---
+/**
+ * Write a new post.
+ *
+ * The POST is handled here rather than in an API route on purpose. A route
+ * would have to redirect back on a validation error, and a redirect throws away
+ * the request body — which on this screen is somebody's entire essay. Handling
+ * it in the page means a rejected submission re-renders the form with every
+ * character still in it.
+ *
+ * The write itself mirrors the MCP `publish_post` handler exactly, so a post
+ * written in the browser is indistinguishable from one published over MCP.
+ */
+export const prerender = false;
+
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PostForm from '../../components/PostForm.astro';
+import { isAdmin, ADMIN_COOKIE } from '../../lib/admin';
+import { sql, hasDatabase } from '../../lib/db';
+import { autoExcerpt } from '../../lib/markdown';
+import { slugify, estimateMinutes, type PostKind } from '../../lib/posts';
+
+let authed = false;
+try {
+  authed = await isAdmin(Astro.cookies.get(ADMIN_COOKIE)?.value);
+} catch {
+  authed = false;
+}
+
+// Never let a CDN or shared cache hand an authenticated page to the next visitor.
+Astro.response.headers.set('Cache-Control', 'private, no-store');
+Astro.response.headers.set('Vary', 'Cookie');
+
+const showError = Astro.url.searchParams.get('error') === '1';
+
+let values = {
+  title: '',
+  slug: '',
+  kind: 'essay' as PostKind,
+  excerpt: '',
+  body: '',
+  tags: '',
+  coverImage: '',
+  featured: false,
+};
+
+const errors: Record<string, string> = {};
+const dbMissing = authed && !hasDatabase();
+
+if (Astro.request.method === 'POST') {
+  // Same posture as the mutation routes: a forged or stale POST is refused
+  // outright rather than redirected, so it reveals nothing about this page.
+  if (!authed) return new Response('Forbidden', { status: 403 });
+  if (!hasDatabase()) return new Response('No database configured', { status: 503 });
+
+  let form: FormData;
+  try {
+    form = await Astro.request.formData();
+  } catch {
+    return new Response('Bad request', { status: 400 });
+  }
+
+  const text = (name: string): string => {
+    const v = form.get(name);
+    return typeof v === 'string' ? v : '';
+  };
+
+  values = {
+    title: text('title').trim(),
+    slug: text('slug').trim(),
+    kind: text('kind') === 'book-note' ? 'book-note' : 'essay',
+    excerpt: text('excerpt').trim(),
+    // Body is kept verbatim — this is the one field where "helpfully" tidying
+    // the input would be felt.
+    body: text('body'),
+    tags: text('tags'),
+    coverImage: text('cover_image').trim(),
+    featured: form.get('featured') !== null,
+  };
+
+  const publish = text('action') === 'publish';
+
+  if (!values.title) errors.title = 'A title is required.';
+  if (!values.body.trim()) errors.body = 'A body is required.';
+
+  const finalSlug = slugify(values.slug || values.title);
+  if (!finalSlug && !errors.title) {
+    errors.slug = 'Could not derive a slug from that title — enter one explicitly.';
+  }
+
+  if (finalSlug && Object.keys(errors).length === 0) {
+    const clash = await sql()`SELECT slug FROM posts WHERE slug = ${finalSlug} LIMIT 1`;
+    if (clash.length) errors.slug = 'A post with that slug already exists.';
+  }
+
+  if (Object.keys(errors).length === 0) {
+    const tags = values.tags
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+    const status = publish ? 'published' : 'draft';
+
+    await sql()`
+      INSERT INTO posts (slug, title, excerpt, body_md, kind, status, featured, tags, cover_image, read_minutes, published_at)
+      VALUES (
+        ${finalSlug}, ${values.title}, ${values.excerpt || autoExcerpt(values.body)}, ${values.body},
+        ${values.kind}, ${status}, ${values.featured}, ${tags}, ${values.coverImage || null},
+        ${estimateMinutes(values.body)},
+        ${status === 'published' ? new Date().toISOString() : null}
+      )`;
+
+    return Astro.redirect('/admin', 303);
+  }
+
+  // Fell through: re-render below with `values` and `errors` intact.
+  Astro.response.status = 422;
+}
+
+const hasErrors = Object.keys(errors).length > 0;
+---
+
+<BaseLayout title="New post" description="Blog administration.">
+  <meta slot="head" name="robots" content="noindex, nofollow, noarchive" />
+
+  {
+    !authed ? (
+      <section class="container--reading gate">
+        <p class="eyebrow">Restricted</p>
+        <h1 class="gate__title">Admin</h1>
+        <p class="gate__copy">This area manages the blog. Enter the admin password to continue.</p>
+
+        <form class="gate__form" method="post" action="/api/admin/login">
+          <input type="hidden" name="redirect" value="/admin" />
+          <label class="field__label" for="admin-password">
+            Password
+          </label>
+          <input
+            class="field__input"
+            id="admin-password"
+            name="password"
+            type="password"
+            placeholder="Password"
+            autocomplete="current-password"
+            required
+          />
+          <button class="btn btn--dark" type="submit">
+            Sign in
+          </button>
+        </form>
+
+        {showError && (
+          <p class="msg msg--error" role="alert">
+            That password is not right. Try again.
+          </p>
+        )}
+      </section>
+    ) : (
+      <section class="container admin">
+        <header class="admin__head">
+          <div>
+            <p class="eyebrow">Blog administration</p>
+            <h1 class="admin__title">New post</h1>
+            <p class="admin__count">Saved as a draft unless you publish it</p>
+          </div>
+
+          <a class="btn btn--ghost-light" href="/admin">
+            All posts
+          </a>
+        </header>
+
+        {dbMissing && (
+          <p class="msg msg--error" role="alert">
+            DATABASE_URL is not set, so there is nothing to write to.
+          </p>
+        )}
+
+        {hasErrors && (
+          <p class="msg msg--error" role="alert">
+            The post was not saved. Fix the fields marked below — nothing you typed was lost.
+          </p>
+        )}
+
+        <PostForm mode="new" values={values} errors={errors} />
+      </section>
+    )
+  }
+</BaseLayout>
+
+<style>
+  /* ------------------------------------------------------------- gate */
+  .gate {
+    padding-block: 90px 120px;
+    max-width: 460px;
+  }
+
+  .gate .eyebrow {
+    margin-bottom: 20px;
+  }
+
+  .gate__title {
+    font-weight: var(--w-black);
+    font-size: 40px;
+    line-height: 1;
+    letter-spacing: -0.02em;
+    margin-bottom: 16px;
+  }
+
+  .gate__copy {
+    font-size: 16px;
+    font-weight: var(--w-light);
+    line-height: 1.6;
+    color: var(--text-on-light-muted);
+    margin-bottom: 32px;
+  }
+
+  .gate__form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .field__label {
+    font-size: 11px;
+    font-weight: var(--w-bold);
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-on-light-soft);
+  }
+
+  .field__input {
+    min-height: 52px;
+    padding-inline: 16px;
+    border: 1px solid var(--border-input);
+    background: var(--paper);
+    font-family: inherit;
+    font-size: 16px;
+    color: var(--text-on-light);
+    outline: none;
+  }
+
+  .field__input:focus-visible {
+    outline: 2px solid var(--gold);
+    outline-offset: -2px;
+  }
+
+  .gate__form .btn {
+    margin-top: 6px;
+  }
+
+  /* ---------------------------------------------------------- messages */
+  .msg {
+    font-size: 14px;
+    line-height: 1.5;
+    padding: 14px 16px;
+    margin-bottom: 24px;
+    border-left: 3px solid var(--gold);
+    background: var(--paper-warm);
+    color: var(--text-on-light-muted);
+  }
+
+  .msg--error {
+    border-left-color: var(--rust);
+    color: var(--rust);
+  }
+
+  .gate .msg {
+    margin-top: 20px;
+    margin-bottom: 0;
+  }
+
+  /* ------------------------------------------------------------ layout */
+  .admin {
+    padding-block: 70px 100px;
+  }
+
+  /* Capped to the form's measure so the head rule and the field hairlines are
+     one continuous column rather than two different widths. */
+  .admin__head,
+  .msg {
+    max-width: 780px;
+  }
+
+  .admin__head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+    padding-bottom: 26px;
+    margin-bottom: 30px;
+    border-bottom: 1px solid var(--rule-light);
+  }
+
+  .admin__head .eyebrow {
+    margin-bottom: 12px;
+  }
+
+  .admin__title {
+    font-weight: var(--w-black);
+    font-size: 40px;
+    line-height: 1;
+    letter-spacing: -0.02em;
+  }
+
+  .admin__count {
+    margin-top: 12px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.06em;
+    color: var(--text-on-light-faint);
+  }
+
+  .admin__head .btn {
+    min-height: 44px;
+    flex: none;
+  }
+
+  @media (max-width: 720px) {
+    .admin {
+      padding-block: 50px 80px;
+    }
+
+    .admin__head {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .admin__title {
+      font-size: 32px;
+    }
+  }
+</style>

--- a/src/pages/api/admin/upload.ts
+++ b/src/pages/api/admin/upload.ts
@@ -1,0 +1,98 @@
+import type { APIRoute } from 'astro';
+import { isAdmin, ADMIN_COOKIE } from '../../../lib/admin';
+import {
+  MAX_UPLOAD_BYTES,
+  MEDIA_PATH,
+  imageSize,
+  mediaKey,
+  mediaStore,
+  sniffImage,
+} from '../../../lib/media';
+
+export const prerender = false;
+
+const json = (body: unknown, status: number): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', 'cache-control': 'private, no-store' },
+  });
+
+/**
+ * Accept an image from the admin editor and store it in Netlify Blobs.
+ *
+ * Same posture as every other admin mutation: the session is re-checked here
+ * rather than trusted from the page that drew the control, and a caller without
+ * one gets 403. An open upload endpoint would be an open file host.
+ *
+ * The declared Content-Type and the filename extension are used for nothing.
+ * The stored type comes from sniffing the actual bytes, which is also what the
+ * key's extension and the served Content-Type are derived from — so there is no
+ * path by which a caller's claim about a file becomes a claim we repeat.
+ */
+export const POST: APIRoute = async ({ request, cookies }) => {
+  let allowed = false;
+  try {
+    allowed = await isAdmin(cookies.get(ADMIN_COOKIE)?.value);
+  } catch {
+    allowed = false;
+  }
+  if (!allowed) return json({ error: 'Forbidden' }, 403);
+
+  // Cheap early rejection so an oversized body is not buffered at all.
+  const declared = Number(request.headers.get('content-length') ?? 0);
+  if (declared > MAX_UPLOAD_BYTES * 1.05) {
+    return json({ error: 'That image is over the 10 MB limit.' }, 413);
+  }
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return json({ error: 'Could not read the upload.' }, 400);
+  }
+
+  const file = form.get('file');
+  if (!(file instanceof File) || file.size === 0) {
+    return json({ error: 'No file was attached.' }, 400);
+  }
+
+  if (file.size > MAX_UPLOAD_BYTES) {
+    const mb = (file.size / (1024 * 1024)).toFixed(1);
+    return json({ error: `That image is ${mb} MB — the limit is 10 MB.` }, 413);
+  }
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  if (bytes.byteLength > MAX_UPLOAD_BYTES) {
+    return json({ error: 'That image is over the 10 MB limit.' }, 413);
+  }
+
+  const type = sniffImage(bytes);
+  if (!type) {
+    return json(
+      { error: 'That file is not a JPEG, PNG, WebP, GIF or AVIF image.' },
+      415
+    );
+  }
+
+  const key = await mediaKey(bytes, file.name || 'image', type.ext);
+
+  try {
+    // Idempotent by construction: the same bytes produce the same key, so a
+    // re-upload overwrites itself with identical content.
+    const store = await mediaStore();
+    await store.put(key, bytes, type.mime);
+  } catch {
+    return json({ error: 'The image store is not available. Nothing was saved.' }, 503);
+  }
+
+  const size = imageSize(bytes, type.ext);
+
+  return json(
+    {
+      url: `${MEDIA_PATH}${key}`,
+      name: file.name || key,
+      ...(size ?? {}),
+    },
+    201
+  );
+};

--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -2,22 +2,14 @@ import type { APIRoute } from 'astro';
 import { sql, hasDatabase } from '../../lib/db';
 import { handleRpc, type JsonRpcRequest, type ToolDefinition, PROTOCOL_VERSION } from '../../lib/mcp';
 import { autoExcerpt } from '../../lib/markdown';
+// Shared with the browser admin so a post written in either place gets the same
+// slug and the same read_minutes estimate.
+import { slugify, estimateMinutes } from '../../lib/posts';
 import { getSecret } from 'astro:env/server';
 
 export const prerender = false;
 
 /* ------------------------------------------------------------------ helpers */
-
-const slugify = (s: string): string =>
-  s
-    .toLowerCase()
-    .normalize('NFKD')
-    .replace(/[̀-ͯ]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 80);
-
-const estimateMinutes = (md: string): number => Math.max(1, Math.round(md.split(/\s+/).length / 220));
 
 const token = (): string | null => getSecret('BLOG_API_TOKEN') ?? null;
 

--- a/src/pages/media/[...key].ts
+++ b/src/pages/media/[...key].ts
@@ -1,0 +1,47 @@
+import type { APIRoute } from 'astro';
+import { MIME_BY_EXT, extensionOf, isMediaKey, mediaStore } from '../../lib/media';
+
+export const prerender = false;
+
+/**
+ * Serve an uploaded post image.
+ *
+ * Public on purpose — these are illustrations inside published posts, and a
+ * gated image would simply break every reader's page. The key is a content
+ * hash, so it is unguessable and immutable: the same URL always returns the
+ * same bytes, which is what earns the year-long immutable cache.
+ *
+ * The Content-Type comes from the extension baked into the key at upload time,
+ * which was itself derived from sniffed magic bytes — never from anything a
+ * requester or an uploader asserted. `nosniff` stops a browser from second-
+ * guessing it.
+ */
+export const GET: APIRoute = async ({ params }) => {
+  const key = params.key ?? '';
+
+  // Reject anything that is not shaped like a key we minted, before touching
+  // the store — that also rules out path traversal in the dev file fallback.
+  if (!isMediaKey(key)) return new Response('Not found', { status: 404 });
+
+  let stored: Awaited<ReturnType<Awaited<ReturnType<typeof mediaStore>>['get']>> = null;
+  try {
+    const store = await mediaStore();
+    stored = await store.get(key);
+  } catch {
+    return new Response('Image storage unavailable', { status: 503 });
+  }
+
+  if (!stored) return new Response('Not found', { status: 404 });
+
+  const mime = MIME_BY_EXT[extensionOf(key)] ?? stored.mime ?? 'application/octet-stream';
+
+  return new Response(stored.bytes as unknown as ArrayBuffer, {
+    status: 200,
+    headers: {
+      'content-type': mime,
+      'content-length': String(stored.bytes.byteLength),
+      'cache-control': 'public, max-age=31536000, immutable',
+      'x-content-type-options': 'nosniff',
+    },
+  });
+};


### PR DESCRIPTION
The admin console could list, publish and delete posts, but there was no way to **write** one — it was built as a management screen and never grew an editor. This adds authoring, editing and image upload.

## Authoring

- `/admin/new` and `/admin/edit/[slug]`, sharing a `PostForm` component: title, slug, kind, excerpt, a 26-row monospace body, tags, cover image, featured.
- Both pages **handle their own POST** rather than delegating to an API route, so a validation error (duplicate slug, missing title) re-renders the form with everything still typed in it. Losing a long post to a redirect is the worst failure this screen could have.
- `slugify()` and `estimateMinutes()` moved into `lib/posts.ts`; the MCP endpoint now imports them instead of keeping its own copies, so a post written in the browser and one published over MCP can't drift apart.
- The safe button is first in tab order (Save as draft / Save), so a stray Enter never publishes.

## Images

Stored in **Netlify Blobs**, served from `/media/<key>` with an immutable cache header. No third-party service.

- Admin-gated — 403 without a session. This is not an open upload endpoint.
- Type checked by **magic bytes**, not the filename or `Content-Type`, both of which the client controls. SVG refused outright (it can carry script).
- 10 MB cap; content-hash keys, so re-uploading the same file is idempotent and keys aren't guessable.
- Cover image gets a file picker with live preview; **Insert image** drops `![alt](url)` at the caret in the body.
- Progressive enhancement: with JS off the cover is still a plain text field and the post still saves.

**Uploads are stored as-is** — no resizing or re-encoding. A 12 MP phone photo stays 12 MP. Worth revisiting via Netlify's Image CDN if that becomes a problem.

## Also

Light and dark header padding equalised at 26px — they were 20 and 26, which read as an inconsistency when moving between pages.

## Verification

`astro check` 0 errors, `npm run build` passes. Security-relevant behaviour re-tested independently of the agent that wrote it:

| Check | Result |
|---|---|
| Logged-out GET `/admin/new`, `/admin/edit/<slug>` | password form only, no post data |
| Logged-out POST `/api/admin/upload` | 403 |
| HTML renamed `.png` with spoofed `image/png` header | 415 |
| Real PNG round-trip | 201 → served back byte-identical as `image/png` |

Database left at 7 rows; test post and dev blobs cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)