### PR TITLE
Fix a stale home page, a self-generated excerpt and cropped covers

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -98,10 +98,15 @@ const excerpt = post.excerpt ?? autoExcerpt(post.bodyMd);
   }
 
   /* ------------------------------------------------------------- featured */
+  /* 16:9 rather than a fixed height. A fixed 340px forced whatever the author
+     uploaded into roughly 2.35:1, which silently sliced the top and bottom off
+     a normal 16:9 cover — and title-card covers carry their text up there. */
   .pc--featured .pc__cover {
     width: 100%;
-    height: 340px;
+    aspect-ratio: 16 / 9;
+    height: auto;
     object-fit: cover;
+    object-position: center;
   }
 
   .pc__cover--placeholder {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -12,13 +12,41 @@ marked.setOptions({ gfm: true, breaks: false });
  */
 export const renderMarkdown = (md: string): string => marked.parse(md, { async: false }) as string;
 
-/** First paragraph, flattened — used when a post has no explicit excerpt. */
+/**
+ * First paragraph, flattened — a fallback for listings and meta descriptions
+ * when a post has no excerpt of its own.
+ *
+ * Cuts at a sentence end where there is one near the limit, and otherwise at a
+ * word boundary. The earlier version sliced at exactly `max` characters, which
+ * produced endings like "…I always liked writing Rea…".
+ */
 export const autoExcerpt = (md: string, max = 220): string => {
   const firstPara = md
     .split(/\n{2,}/)
     .map((b) => b.trim())
     .find((b) => b && !b.startsWith('#') && !b.startsWith('!['));
   if (!firstPara) return '';
-  const text = firstPara.replace(/[*_`>#]/g, '').replace(/\[(.*?)\]\(.*?\)/g, '$1').trim();
-  return text.length > max ? `${text.slice(0, max).trimEnd()}…` : text;
+
+  const text = firstPara
+    .replace(/[*_`>#]/g, '')
+    .replace(/\[(.*?)\]\(.*?\)/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (text.length <= max) return text;
+
+  const window = text.slice(0, max + 1);
+
+  // Prefer ending on a complete sentence, if one finishes in the back half.
+  const sentenceEnd = Math.max(
+    window.lastIndexOf('. '),
+    window.lastIndexOf('! '),
+    window.lastIndexOf('? ')
+  );
+  if (sentenceEnd > max * 0.5) return window.slice(0, sentenceEnd + 1);
+
+  // Otherwise cut at the last whole word.
+  const lastSpace = window.lastIndexOf(' ');
+  const cut = lastSpace > 0 ? window.slice(0, lastSpace) : window.slice(0, max);
+  return `${cut.replace(/[),.;:—-]+$/, '').trimEnd()}…`;
 };

--- a/src/pages/admin/edit/[slug].astro
+++ b/src/pages/admin/edit/[slug].astro
@@ -18,7 +18,6 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
 import PostForm from '../../../components/PostForm.astro';
 import { isAdmin, ADMIN_COOKIE } from '../../../lib/admin';
 import { sql, hasDatabase } from '../../../lib/db';
-import { autoExcerpt } from '../../../lib/markdown';
 import { slugify, estimateMinutes, type PostKind, type PostStatus } from '../../../lib/posts';
 
 let authed = false;
@@ -133,7 +132,7 @@ if (Astro.request.method === 'POST') {
       UPDATE posts SET
         slug         = ${nextSlug},
         title        = ${values.title},
-        excerpt      = ${values.excerpt || autoExcerpt(values.body)},
+        excerpt      = ${values.excerpt || null},
         body_md      = ${values.body},
         kind         = ${values.kind},
         status       = ${status},

--- a/src/pages/admin/new.astro
+++ b/src/pages/admin/new.astro
@@ -17,7 +17,6 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import PostForm from '../../components/PostForm.astro';
 import { isAdmin, ADMIN_COOKIE } from '../../lib/admin';
 import { sql, hasDatabase } from '../../lib/db';
-import { autoExcerpt } from '../../lib/markdown';
 import { slugify, estimateMinutes, type PostKind } from '../../lib/posts';
 
 let authed = false;
@@ -103,7 +102,7 @@ if (Astro.request.method === 'POST') {
     await sql()`
       INSERT INTO posts (slug, title, excerpt, body_md, kind, status, featured, tags, cover_image, read_minutes, published_at)
       VALUES (
-        ${finalSlug}, ${values.title}, ${values.excerpt || autoExcerpt(values.body)}, ${values.body},
+        ${finalSlug}, ${values.title}, ${values.excerpt || null}, ${values.body},
         ${values.kind}, ${status}, ${values.featured}, ${tags}, ${values.coverImage || null},
         ${estimateMinutes(values.body)},
         ${status === 'published' ? new Date().toISOString() : null}

--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -1,7 +1,6 @@
 import type { APIRoute } from 'astro';
 import { sql, hasDatabase } from '../../lib/db';
 import { handleRpc, type JsonRpcRequest, type ToolDefinition, PROTOCOL_VERSION } from '../../lib/mcp';
-import { autoExcerpt } from '../../lib/markdown';
 // Shared with the browser admin so a post written in either place gets the same
 // slug and the same read_minutes estimate.
 import { slugify, estimateMinutes } from '../../lib/posts';
@@ -156,7 +155,7 @@ const tools: ToolDefinition[] = [
       const rows = await sql()`
         INSERT INTO posts (slug, title, excerpt, body_md, kind, status, featured, tags, cover_image, read_minutes, published_at)
         VALUES (
-          ${finalSlug}, ${title}, ${excerpt ?? autoExcerpt(body_md)}, ${body_md}, ${kind}, ${status},
+          ${finalSlug}, ${title}, ${excerpt ?? null}, ${body_md}, ${kind}, ${status},
           ${featured}, ${tags}, ${cover_image}, ${estimateMinutes(body_md)},
           ${status === 'published' ? new Date().toISOString() : null}
         )

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -54,7 +54,15 @@ const view =
   post &&
   (() => {
     const { quote, rest } = splitPullQuote(post.bodyMd);
-    const excerpt = post.excerpt ?? autoExcerpt(rest);
+
+    /* Two different jobs, deliberately not the same value.
+       `standfirst` is the line printed under the title, and only exists when
+       the author wrote one. `metaDescription` always needs *something* for
+       search and social cards, so it falls back to the opening paragraph.
+       Using the fallback for both meant a post with no excerpt printed its own
+       first sentence back at the reader, truncated — which read as a bug. */
+    const standfirst = post.excerpt?.trim() || null;
+    const metaDescription = standfirst ?? autoExcerpt(rest);
     const canonical = new URL(`/blog/${post.slug}`, site.url).href;
 
     return {
@@ -62,13 +70,14 @@ const view =
       date: formatDate(post.publishedAt),
       read: readingTime(post),
       pullQuote: quote,
-      excerpt,
+      excerpt: standfirst,
+      metaDescription,
       body: renderMarkdown(rest),
       jsonLd: {
         '@context': 'https://schema.org',
         '@type': 'BlogPosting',
         headline: post.title,
-        description: excerpt,
+        description: metaDescription,
         datePublished: post.publishedAt ?? post.createdAt,
         dateModified: post.updatedAt,
         mainEntityOfPage: { '@type': 'WebPage', '@id': canonical },
@@ -109,7 +118,7 @@ const view =
   post && view && (
     <BaseLayout
       title={post.title}
-      description={view.excerpt}
+      description={view.metaDescription}
       ogImage={post.coverImage ?? undefined}
       article={{ publishedAt: post.publishedAt, kind: post.kind }}
     >
@@ -144,7 +153,7 @@ const view =
             src={post.coverImage}
             alt=""
             width="760"
-            height="300"
+            height="428"
             decoding="async"
           />
         ) : (
@@ -259,10 +268,14 @@ const view =
     color: var(--text-on-light-muted);
   }
 
+  /* See PostCard: 16:9 so a cover is shown as composed rather than cropped to
+     a letterbox that cuts off any text in the artwork. */
   .post__cover {
     width: 100%;
-    height: 300px;
+    aspect-ratio: 16 / 9;
+    height: auto;
     object-fit: cover;
+    object-position: center;
     border: 1px solid var(--rule-light);
     margin-bottom: 50px;
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,14 +8,16 @@ import { listPosts, formatDate, readingTime, kindLabel } from '../lib/posts';
 import { autoExcerpt } from '../lib/markdown';
 
 /**
- * The home page is fully prerendered: it is the most-hit, least-dynamic page on
- * the site, and nothing here depends on the request.
+ * Rendered per request, because "Latest from the blog" reads the database.
  *
- * Consequence worth knowing: the "Latest from the blog" list below is baked in
- * at build time, so publishing a post does not change this page until the next
- * build. /blog itself renders per-request and is always current.
+ * This page was prerendered at first, on the reasoning that the home page is
+ * the most-hit and least-dynamic page on the site. That was wrong in practice:
+ * the post list was baked in at build time, so publishing or unpublishing left
+ * the home page advertising stale posts until something else triggered a
+ * deploy. A home page that contradicts /blog is worse than one that costs a
+ * database round trip.
  */
-export const prerender = true;
+export const prerender = false;
 
 const posts = await listPosts({ limit: 5 });
 const featured = posts[0];


### PR DESCRIPTION
Three bugs that surfaced as soon as a real post went up.

### 1. Home page showed unpublished posts
It was prerendered, so its post list was a build-time snapshot while `/blog` rendered per request. The two disagreed. Home now renders per request — a database round trip is cheaper than a home page that misrepresents what's published.

### 2. The post page printed a truncated copy of its own opening
Two causes:
- **All three write paths** (admin create, admin edit, MCP publish) *stored* the generated excerpt into the column. Every read path already falls back to generating one, so storing it was redundant — and it froze a machine-written line into the post, which then rendered as the standfirst. An excerpt is now stored only when the author writes one; the standfirst renders only when it exists. Meta descriptions still fall back, since search and social cards always need text.
- `autoExcerpt` sliced at exactly 220 characters, mid-word (`…I always liked writing Rea…`). It now ends on a sentence boundary where one is available, and a word boundary otherwise.

The stored excerpt on the live post was cleared after confirming it was byte-identical to the old generator's output, i.e. machine-written rather than authored.

### 3. Covers were cropped to a letterbox
The featured card forced `height: 340px` and the post hero `300px`, squeezing a 16:9 image into roughly 2.4:1 and cutting off the top and bottom — exactly where a title-card cover carries its text. Both now use `aspect-ratio: 16 / 9`.

Verified locally: home lists the correct post, no standfirst element renders, the meta description still falls back, and the truncated fragment is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)