### PR TITLE
Convert rich text to Markdown when pasted into the editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,13 @@
         "@neondatabase/serverless": "^1.1.0",
         "@netlify/blobs": "^10.7.10",
         "astro": "^7.1.3",
-        "marked": "^18.0.7"
+        "marked": "^18.0.7",
+        "turndown": "^7.2.4",
+        "turndown-plugin-gfm": "^1.0.2"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
+        "@types/turndown": "^5.0.6",
         "typescript": "^5.9.3"
       }
     },
@@ -1935,6 +1938,12 @@
         }
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -3363,6 +3372,13 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -11168,6 +11184,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "license": "MIT"
     },
     "node_modules/type-fest": {
       "version": "4.41.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "private": true,
   "type": "module",
-  "description": "treder.design \u2014 portfolio, writing and book of Marcin Treder",
+  "description": "treder.design — portfolio, writing and book of Marcin Treder",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
@@ -16,10 +16,13 @@
     "@neondatabase/serverless": "^1.1.0",
     "@netlify/blobs": "^10.7.10",
     "astro": "^7.1.3",
-    "marked": "^18.0.7"
+    "marked": "^18.0.7",
+    "turndown": "^7.2.4",
+    "turndown-plugin-gfm": "^1.0.2"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "@types/turndown": "^5.0.6",
     "typescript": "^5.9.3"
   }
 }

--- a/src/components/PostForm.astro
+++ b/src/components/PostForm.astro
@@ -144,7 +144,16 @@ const kinds: PostKind[] = ['essay', 'book-note'];
       spellcheck="true"
       required
       aria-describedby={errors.body ? 'err-body' : 'hint-body'}>{values.body}</textarea>
-    <p class="field__hint" id="hint-body">Markdown. Inline HTML is allowed.</p>
+
+    {/* Filled in by the paste handler when a pasted image points at a source
+        that will not last — Google's CDN, a data: URI. Empty and hidden until
+        then, and never rendered on the server. */}
+    <p class="field__warn" id="paste-warn" role="status" aria-live="polite" hidden></p>
+
+    <p class="field__hint" id="hint-body">
+      Markdown. Inline HTML is allowed. Pasting from Google Docs, Word or a web page converts the
+      formatting for you — headings, bold, lists and links all come across.
+    </p>
     {
       errors.body && (
         <p class="field__error" id="err-body" role="alert">
@@ -257,6 +266,8 @@ const kinds: PostKind[] = ['essay', 'book-note'];
    * and are only revealed once this script runs, the cover field stays an
    * ordinary text input, and a failed upload leaves the form exactly as it was.
    */
+  import { htmlToMarkdown, PLACEHOLDER_PREFIX } from '../lib/rich-paste';
+
   const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T | null;
 
   const coverBlock = $<HTMLDivElement>('cover-block');
@@ -266,6 +277,7 @@ const kinds: PostKind[] = ['essay', 'book-note'];
   const coverClear = $<HTMLButtonElement>('cover-clear');
   const coverStatus = $<HTMLParagraphElement>('cover-status');
 
+  const pasteWarn = $<HTMLParagraphElement>('paste-warn');
   const bodyBlock = $<HTMLDivElement>('body-uploader');
   const bodyFile = $<HTMLInputElement>('body-file');
   const bodyArea = $<HTMLTextAreaElement>('post-body');
@@ -398,6 +410,89 @@ const kinds: PostKind[] = ['essay', 'book-note'];
       }
     });
   }
+
+  /* ------------------------------------------------------------ rich paste */
+  /**
+   * The body is a Markdown field, but the drafts arrive from Google Docs. When
+   * the clipboard carries an HTML flavour we convert it and insert that; when
+   * it does not — a code snippet, a URL, anything copied as plain text — this
+   * handler returns before `preventDefault` and the browser pastes as always.
+   */
+  if (bodyArea) {
+    /** Insert at the caret, replacing the selection, keeping undo if we can. */
+    const insertAtCaret = (text: string) => {
+      bodyArea.focus();
+
+      // execCommand is deprecated but it is still the only way to write into a
+      // textarea and leave the undo stack intact. Where it is gone, splice the
+      // value directly and tell the page the field changed.
+      let inserted = false;
+      try {
+        inserted = document.execCommand('insertText', false, text);
+      } catch {
+        inserted = false;
+      }
+      if (inserted) return;
+
+      const start = bodyArea.selectionStart ?? bodyArea.value.length;
+      const end = bodyArea.selectionEnd ?? start;
+      bodyArea.value = bodyArea.value.slice(0, start) + text + bodyArea.value.slice(end);
+      const caret = start + text.length;
+      bodyArea.setSelectionRange(caret, caret);
+      bodyArea.dispatchEvent(new Event('input', { bubbles: true }));
+    };
+
+    const warnAboutImages = (count: number) => {
+      if (!pasteWarn) return;
+      if (count < 1) {
+        pasteWarn.hidden = true;
+        pasteWarn.textContent = '';
+        return;
+      }
+      const plural = count === 1 ? 'image' : 'images';
+      pasteWarn.textContent =
+        `${count} pasted ${plural} could not be brought across: Google Docs serves them from ` +
+        `links that stop working. Each one is marked ${PLACEHOLDER_PREFIX}N in the text — put the ` +
+        `caret on it and use Insert image to upload the real file.`;
+      pasteWarn.hidden = false;
+    };
+
+    bodyArea.addEventListener('paste', (event) => {
+      const clipboard = event.clipboardData;
+      if (!clipboard) return;
+
+      const html = clipboard.getData('text/html');
+      if (!html.trim()) return; // plain text — nothing to convert
+
+      let markdown = '';
+      let volatileImages = 0;
+      try {
+        ({ markdown, volatileImages } = htmlToMarkdown(html));
+      } catch {
+        return; // a paste is never worth breaking over; let the browser do it
+      }
+      if (!markdown) return;
+
+      // Plenty of apps put an HTML flavour on the clipboard for what is really
+      // plain text — a code editor colouring a snippet, a browser wrapping a
+      // URL in a styled span. If the conversion carries no markup the text
+      // flavour did not already have, stepping in would only add backslashes
+      // in front of the Markdown characters and cost the browser's own undo
+      // entry. Compare with the escaping and the line wrapping taken out.
+      const bare = (value: string) =>
+        value
+          .replace(/\\([\\`*_{}[\]()#+\-.!~<>|])/g, '$1')
+          .replace(/\s+/g, ' ')
+          .trim();
+      const plain = clipboard.getData('text/plain');
+      if (plain && bare(plain) === bare(markdown)) return;
+
+      event.preventDefault();
+      insertAtCaret(markdown);
+      warnAboutImages(volatileImages);
+      say(bodyStatus, 'Pasted formatting converted to Markdown.', 'ok');
+    });
+  }
 </script>
 
 <style>
@@ -508,6 +603,16 @@ const kinds: PostKind[] = ['essay', 'book-note'];
     padding-left: 12px;
     border-left: 3px solid var(--rust);
     color: var(--rust);
+  }
+
+  /* Softer than .field__error — the save is fine, the images are not. */
+  .field__warn {
+    font-size: 13px;
+    font-weight: var(--w-light);
+    line-height: 1.5;
+    padding-left: 12px;
+    border-left: 3px solid var(--gold);
+    color: var(--text-on-light-muted);
   }
 
   /* ------------------------------------------------------------- uploader */

--- a/src/lib/rich-paste.ts
+++ b/src/lib/rich-paste.ts
@@ -1,0 +1,291 @@
+/**
+ * Rich text → Markdown, for the post editor's paste handler.
+ *
+ * The author drafts in Google Docs. Google's clipboard HTML is dirty in
+ * specific, well-known ways — the whole document arrives wrapped in a
+ * `<b style="font-weight:normal">`, emphasis is carried on `<span>` styles
+ * rather than `<b>`/`<em>`, and images are `googleusercontent.com` URLs that
+ * stop resolving before long. Turndown alone would turn the first into a
+ * document-sized `**bold**` run, drop the second entirely, and embed the third
+ * as if it were a real asset. Everything here exists to fix one of those.
+ *
+ * Word and ordinary web pages come through the same path; the Word-specific
+ * bits are limited to its `mso-list` bullet noise.
+ *
+ * Kept free of DOM APIs of its own so it runs unchanged in the browser and
+ * under `node` in a test — Turndown supplies the parser at both ends.
+ */
+import TurndownService from 'turndown';
+// @ts-expect-error — turndown-plugin-gfm ships no type declarations.
+import { strikethrough, tables } from 'turndown-plugin-gfm';
+
+export interface ConvertedPaste {
+  /** Markdown ready to drop at the caret. */
+  markdown: string;
+  /**
+   * How many images referenced a source that will not survive — Google's
+   * temporary CDN, a `data:`/`blob:` URI, a local file. Each one is left in the
+   * text as a `REPLACE-ME-image-N` placeholder rather than a broken embed.
+   */
+  volatileImages: number;
+}
+
+/** The href written into the body for an image that has to be re-uploaded. */
+const PLACEHOLDER = (index: number) => `REPLACE-ME-image-${index}`;
+
+type El = HTMLElement;
+
+/** Read one declaration out of an inline `style` attribute. */
+const styleOf = (node: El, property: string): string => {
+  const raw = typeof node.getAttribute === 'function' ? node.getAttribute('style') : null;
+  if (!raw) return '';
+  const found = new RegExp(`(?:^|;)\\s*${property}\\s*:\\s*([^;]*)`, 'i').exec(raw);
+  return found ? found[1].trim().toLowerCase() : '';
+};
+
+const isBoldWeight = (weight: string): boolean => {
+  if (!weight) return false;
+  if (weight === 'bold' || weight === 'bolder') return true;
+  const numeric = Number.parseInt(weight, 10);
+  return Number.isFinite(numeric) && numeric >= 600;
+};
+
+const isBoldSpan = (node: El): boolean =>
+  node.nodeName === 'SPAN' && isBoldWeight(styleOf(node, 'font-weight'));
+
+const isItalicSpan = (node: El): boolean =>
+  node.nodeName === 'SPAN' && styleOf(node, 'font-style') === 'italic';
+
+const isStruckSpan = (node: El): boolean =>
+  node.nodeName === 'SPAN' && /line-through/.test(styleOf(node, 'text-decoration'));
+
+/**
+ * Google's outer `<b style="font-weight:normal">` (and the `docs-internal-guid`
+ * wrapper it usually carries) is markup, not emphasis. Word emits the same
+ * shape occasionally. Treat it as transparent.
+ */
+const isFakeBold = (node: El): boolean => {
+  if (node.nodeName !== 'B' && node.nodeName !== 'STRONG') return false;
+  const weight = styleOf(node, 'font-weight');
+  const id = typeof node.getAttribute === 'function' ? node.getAttribute('id') || '' : '';
+  if (id.startsWith('docs-internal-guid')) return true;
+  return weight !== '' && !isBoldWeight(weight);
+};
+
+const ancestors = function* (node: El): Generator<El> {
+  let current = node.parentNode as El | null;
+  while (current && current.nodeName !== 'BODY' && current.nodeName !== '#document') {
+    yield current;
+    current = current.parentNode as El | null;
+  }
+};
+
+const insideHeading = (node: El): boolean => {
+  for (const parent of ancestors(node)) if (/^H[1-6]$/.test(parent.nodeName)) return true;
+  return false;
+};
+
+/** Already inside emphasis of the same kind? Then adding markers again nests them. */
+const alreadyBold = (node: El): boolean => {
+  for (const parent of ancestors(node)) {
+    if (isBoldSpan(parent)) return true;
+    if ((parent.nodeName === 'B' || parent.nodeName === 'STRONG') && !isFakeBold(parent)) return true;
+  }
+  return false;
+};
+
+const alreadyItalic = (node: El): boolean => {
+  for (const parent of ancestors(node)) {
+    if (isItalicSpan(parent)) return true;
+    if (parent.nodeName === 'I' || parent.nodeName === 'EM') return true;
+  }
+  return false;
+};
+
+/**
+ * Google routes some links through `google.com/url?q=…`. Those work, but they
+ * are noise in the source and they die with the redirector, so unwrap them.
+ */
+const cleanHref = (href: string): string => {
+  const trimmed = href.trim();
+  const redirect = /^https?:\/\/(?:www\.)?google\.com\/url\?(.+)$/i.exec(trimmed);
+  if (redirect) {
+    const target = /(?:^|&)(?:q|url)=([^&]+)/.exec(redirect[1]);
+    if (target) {
+      try {
+        return decodeURIComponent(target[1]);
+      } catch {
+        return target[1];
+      }
+    }
+  }
+  return trimmed;
+};
+
+/** Sources that will not still resolve when the post goes out. */
+const isVolatileSource = (src: string): boolean =>
+  src === '' ||
+  /^(?:data|blob|file|cid):/i.test(src) ||
+  /^https?:\/\/[^/]*googleusercontent\.com\//i.test(src) ||
+  /^https?:\/\/[^/]*\.google(?:usercontent)?\.com\/.*\/copy\//i.test(src);
+
+/** Word marks the literal bullet glyph it printed into the HTML. It is noise. */
+const isWordBulletGlyph = (node: El): boolean =>
+  node.nodeName === 'SPAN' && /ignore/i.test(styleOf(node, 'mso-list'));
+
+/** Word's list paragraphs carry `mso-list: l0 level2 lfo1` instead of `<ul>`. */
+const wordListLevel = (node: El): number => {
+  if (node.nodeName !== 'P') return 0;
+  const mso = styleOf(node, 'mso-list');
+  if (!mso || /ignore/i.test(mso)) return 0;
+  const level = /level(\d+)/.exec(mso);
+  return level ? Math.max(1, Number.parseInt(level[1], 10)) : 1;
+};
+
+const wrap = (content: string, marker: string): string =>
+  content.trim() ? marker + content + marker : content;
+
+/**
+ * Convert clipboard HTML to Markdown.
+ *
+ * Pure: no DOM of the host page is touched, nothing is inserted anywhere. The
+ * caller decides what to do with the result and with `volatileImages`.
+ */
+export function htmlToMarkdown(html: string): ConvertedPaste {
+  let volatileImages = 0;
+
+  const service = new TurndownService({
+    headingStyle: 'atx',
+    hr: '---',
+    bulletListMarker: '-',
+    codeBlockStyle: 'fenced',
+    emDelimiter: '_',
+    strongDelimiter: '**',
+    linkStyle: 'inlined',
+  });
+
+  service.use([strikethrough, tables]);
+
+  // Style sheets and scripts ride along in Google's and Word's clipboard HTML;
+  // without this their text content lands in the post body.
+  service.remove(['style', 'script', 'head', 'meta', 'link', 'title', 'noscript']);
+
+  service.addRule('fakeBold', {
+    filter: (node) => isFakeBold(node),
+    replacement: (content) => content,
+  });
+
+  service.addRule('wordBulletGlyph', {
+    filter: (node) => isWordBulletGlyph(node),
+    replacement: () => '',
+  });
+
+  service.addRule('styledSpan', {
+    filter: (node) => isBoldSpan(node) || isItalicSpan(node) || isStruckSpan(node),
+    replacement: (content, node) => {
+      if (!content.trim()) return content;
+      let out = content;
+      if (isStruckSpan(node)) out = wrap(out, '~~');
+      if (isItalicSpan(node) && !alreadyItalic(node)) out = wrap(out, '_');
+      if (isBoldSpan(node) && !alreadyBold(node)) out = wrap(out, '**');
+      return out;
+    },
+  });
+
+  // Added after `styledSpan` so it wins: Turndown gives the most recently
+  // added rule precedence. A heading already reads as a heading, and the
+  // emphasis Google styles inside it is not the author's — `## **Title**`.
+  service.addRule('emphasisInHeading', {
+    filter: (node) =>
+      insideHeading(node) &&
+      (node.nodeName === 'B' ||
+        node.nodeName === 'STRONG' ||
+        node.nodeName === 'I' ||
+        node.nodeName === 'EM' ||
+        node.nodeName === 'SPAN'),
+    replacement: (content) => content,
+  });
+
+  service.addRule('wordListParagraph', {
+    filter: (node) => wordListLevel(node) > 0,
+    replacement: (content, node) => {
+      const body = content.trim().replace(/^[•·▪o§-]\s*/, '');
+      if (!body) return '';
+      const indent = '    '.repeat(wordListLevel(node) - 1);
+      return `\n${indent}- ${body}\n`;
+    },
+  });
+
+  // Turndown pads bullets to four columns (`-   item`) and Google wraps every
+  // item's text in a `<p>`, which opens a blank line between items. Neither is
+  // wrong, both are unlike everything else in this blog's source.
+  service.addRule('listItem', {
+    filter: 'li',
+    replacement: (content, node, options) => {
+      const body = content
+        .replace(/^\n+/, '')
+        .replace(/\n+$/, '')
+        .replace(/\n{2,}(?=\s*[-*+\d])/g, '\n') // sub-lists, not new paragraphs
+        .replace(/\n/g, '\n  ');
+      if (!body) return '';
+
+      const parent = node.parentNode as El | null;
+      let prefix = `${options.bulletListMarker} `;
+      if (parent && parent.nodeName === 'OL') {
+        const start = Number.parseInt(parent.getAttribute('start') || '1', 10);
+        const index = Array.prototype.indexOf.call(parent.children, node);
+        prefix = `${(Number.isFinite(start) ? start : 1) + Math.max(index, 0)}. `;
+      }
+      return `${prefix}${body}\n`;
+    },
+  });
+
+  // The GFM plugin emits a single tilde; every other Markdown tool here reads
+  // the doubled form.
+  service.addRule('strikethrough', {
+    filter: ['del', 's'],
+    replacement: (content) => wrap(content, '~~'),
+  });
+
+  service.addRule('anchor', {
+    filter: (node) => node.nodeName === 'A' && !!node.getAttribute('href'),
+    replacement: (content, node) => {
+      const href = cleanHref(node.getAttribute('href') || '');
+      const text = content.trim();
+      if (!href || href.startsWith('#')) return content;
+      if (!text) return '';
+      return `[${text}](${href})`;
+    },
+  });
+
+  service.addRule('image', {
+    filter: 'img',
+    replacement: (_content, node) => {
+      const src = (node.getAttribute('src') || '').trim();
+      const alt = (node.getAttribute('alt') || '').trim();
+      if (!isVolatileSource(src)) return `![${alt}](${src})`;
+      volatileImages += 1;
+      return `![${alt || `image ${volatileImages}`}](${PLACEHOLDER(volatileImages)})`;
+    },
+  });
+
+  const markdown = tidy(service.turndown(html));
+  return { markdown, volatileImages };
+}
+
+/**
+ * Whitespace only. Smart quotes and dashes are left exactly as Google wrote
+ * them — that is correct typography and the author wants to keep it.
+ */
+function tidy(markdown: string): string {
+  return markdown
+    .replace(/[\u00a0\u2007\u202f]/g, ' ') // non-breaking spaces are invisible landmines
+    .replace(/[\u200b\ufeff]/g, '') // zero width space, from Docs and from web pages
+    .replace(/\r\n?/g, '\n')
+    .replace(/[ \t]+$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/** Exported for the paste handler's warning copy, and for tests. */
+export const PLACEHOLDER_PREFIX = 'REPLACE-ME-image-';


### PR DESCRIPTION
Drafting happens in Google Docs; pasting into the body field lost every heading, bold, italic, list and link.

The body textarea now reads `text/html` off the clipboard and converts it with turndown, inserting Markdown at the caret. Bundled through Astro rather than loaded from a CDN, keeping the site free of external resources.

**Google Docs HTML needs specific handling**, all covered by tests:
- the meaningless `<b style="font-weight:normal">` wrapper that would otherwise make the entire document bold
- emphasis expressed as styled `<span>`s rather than real `<b>`/`<em>` tags
- embedded `<style>` blocks, comments and the `docs-internal-guid` wrapper
- non-breaking spaces, and links wrapped in `google.com/url` redirects

**Images can't be carried across.** Google serves them from `googleusercontent` URLs that stop resolving, so embedding them would leave dead images in a published post. Each becomes a placeholder plus a counted warning pointing at the Insert image button.

**Plain-text paste is untouched** — no `preventDefault` — so pasting a code snippet or URL behaves exactly as before. Testing surfaced a styled bare URL being escaped into `a\_b\_c`; the handler now declines to intervene when conversion adds nothing over the plain-text flavour.

Verified independently against a realistic Docs payload — 11/11 assertions pass, including that no `googleusercontent` URL reaches the body.

**Residual risk, stated plainly:** clipboard events in testing were synthetic `DataTransfer` objects, not a real OS clipboard. Safari and Firefox clipboard flavours are untested, Word's `mso-list` handling covers single-level indent only, and Docs lists nested more than two deep are untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)